### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -42,7 +42,7 @@ export default async function handler(
           try {
             await res.revalidate(localePath)
           } catch (err) {
-            console.error(`Error revalidating ${localePath}`, err)
+            console.error("Error revalidating %s", localePath, err)
             throw new Error(`Error revalidating ${localePath}`)
           }
         })


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/ethereum-org-website/security/code-scanning/1](https://github.com/Dargon789/ethereum-org-website/security/code-scanning/1)

To fix the problem, we should ensure that the user-controlled input is properly sanitized before being included in the format string. The best way to achieve this is by using the `%s` specifier in the format string and passing the user-controlled data as a separate argument to the `console.error` function. This approach ensures that the user-controlled data is treated as a string and prevents any unintended format specifiers from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fixes a code scanning alert related to the use of an externally-controlled format string.