### PR TITLE
Potential fix for code scanning alert no. 3: Shell command built from environment values

### DIFF
--- a/src/scripts/update-chains.ts
+++ b/src/scripts/update-chains.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process"
+import { execSync, execFileSync } from "child_process"
 import fs from "fs"
 import path from "path"
 
@@ -84,7 +84,7 @@ export const updateChainsTsFile = async () => {
   console.log(`Generated/updated ${chainsTsPath}`)
 
   // Run auto-linter on updated TypeScript file
-  execSync(`npx prettier ${chainsTsPath} --write`)
+  execFileSync("npx", ["prettier", chainsTsPath, "--write"])
 }
 
 updateChainsTsFile()


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/ethereum-org-website/security/code-scanning/3](https://github.com/Dargon789/ethereum-org-website/security/code-scanning/3)

The safest solution is to avoid passing a single, interpolated shell command string to `execSync`. Instead, use `execFileSync` from the `child_process` module (or `execSync` with `{shell: false}` and an array of arguments), which allows you to pass the executable and its arguments as separate parameters. This way, any special characters in file paths are handled safely and not interpreted by the shell. Specifically, in `src/scripts/update-chains.ts`, replace:
```ts
execSync(`npx prettier ${chainsTsPath} --write`)
```
with:
```ts
execFileSync('npx', ['prettier', chainsTsPath, '--write'])
```
Also, make sure to import `execFileSync`.

**Steps:**
1. Add an import for `execFileSync` from `child_process`.
2. Replace the `execSync` call with an `execFileSync` call passing `npx` as the command and the rest as arguments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Mitigate potential shell injection by replacing execSync with execFileSync in the update-chains script and importing execFileSync from child_process

Bug Fixes:
- Replace execSync call with execFileSync in update-chains.ts to avoid interpolated shell commands

Enhancements:
- Add import of execFileSync from the child_process module